### PR TITLE
Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 .vscode/
 
 /emotion_onomatopoeia_dictionary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.test.js
+.vscode/
 
 /emotion_onomatopoeia_dictionary

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"liveServer.settings.port": 5501
-}

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 ワークショップ前の事前アウトプット  
 
 - .vscode   
-VSCODEの設定ファイル
+VSCODEの設定ファイル → Git管理からは外すのが一般的とのことでしたので、gitignoreファイルへ追加しました.
+ファイルに書いただけでは、追跡対象から外れずでした。原因はインデックスが残っていたことでコマンドを復習して対処しました。
+`git rm --cached [ファイル名]`
+`git rm -rf --cached [フォルダ名]`  
 - calculator  
-イベントハンドラーの復習のため作成
+イベントハンドラーの復習のため作成  
 - practice  
-DOM操作の復習のため作成
+DOM操作の復習のため作成  
 - emotion_onomatopoeia_dictionary  
-DOM操作の復習のため作成 + gitignoreファイルの使い方
+DOM操作の復習のため作成 + gitignoreファイルの使い方  
 - その他.jsファイルはコーディング問題の内容  


### PR DESCRIPTION
.vscodeフォルダをgit の管理対象から外しました。  
.vscodeフォルダはgitの管理対象に含めないことが一般的とアドバイスいただいたため。  